### PR TITLE
Preferred language bugfix and option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ added documentation tooltips and bug fixes (whitespace changes too)
 
 t-file text
 
+(1.2.1) added preferred language display option and bug fix
+
 # x4codecomplete README
 
 To install, go to releases & download the .vsix file. Then install it like any other program.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x4codecomplete",
-  "version": "1.0.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x4codecomplete",
-      "version": "1.0.2",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "x4codecomplete",
   "displayName": "X4CodeComplete",
   "description": "",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/archenovalis/X4CodeComplete"
@@ -34,10 +34,15 @@
           "default": "",
           "description": "Path to your extensions directory."
         },
-        "x4CodeComplete.language": {
+        "x4CodeComplete.languageNumber": {
           "type": "string",
           "default": "44",
           "description": "Preferred language number (e.g., '44' for English). Files matching this number will be displayed first."
+        },
+        "x4CodeComplete.limitLanguageOutput": {
+          "type": "boolean",
+          "default": false,
+          "description": "Limits the language output to show only the preferred language."
         },
         "x4CodeComplete.exceedinglyVerbose": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 // your extension is activated the very first time the command is executed
 var debug = false;
 var exceedinglyVerbose: boolean = false;
+var limitLanguage: boolean = false;
 var rootpath: string;
 var scriptPropertiesPath: string;
 var extensionsFolder: string;
@@ -554,6 +555,7 @@ function loadLanguageFiles(basePath: string, extensionsFolder: string) {
 function findLanguageText(pageId: string, textId: string): string {
 	const config = vscode.workspace.getConfiguration("x4CodeComplete");
 	const preferredLanguageNumber = config.get("languageNumber") || "44";
+	limitLanguage = config.get("limitLanguageOutput") || false;
 
 	interface Match {
 		fileNumber: string;
@@ -602,10 +604,20 @@ function findLanguageText(pageId: string, textId: string): string {
 
 				console.log(`Extracted fileNumber: ${fileNumber} from ${fileName}`);
 
-				allMatches.push({
-					fileNumber,
-					text: text._.split('\n').map((line: string) => `${fileNumber}: ${line}`).join('\n')
-				});
+				if (limitLanguage){
+                    if (fileNumber == preferredLanguageNumber){
+						allMatches.push({
+							fileNumber,
+							text: text._.split('\n').map((line: string) => `${fileNumber}: ${line}`).join('\n')
+						});
+                    }
+                }
+                else {
+					allMatches.push({
+						fileNumber,
+						text: text._.split('\n').map((line: string) => `${fileNumber}: ${line}`).join('\n')
+					});            
+                }
 			}
 		}
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -605,19 +605,19 @@ function findLanguageText(pageId: string, textId: string): string {
 				console.log(`Extracted fileNumber: ${fileNumber} from ${fileName}`);
 
 				if (limitLanguage){
-                    if (fileNumber == preferredLanguageNumber){
-						allMatches.push({
-							fileNumber,
-							text: text._.split('\n').map((line: string) => `${fileNumber}: ${line}`).join('\n')
-						});
-                    }
-                }
-                else {
+		                    if (fileNumber == preferredLanguageNumber){
+					allMatches.push({
+						fileNumber,
+						text: text._.split('\n').map((line: string) => `${fileNumber}: ${line}`).join('\n')
+					});
+		                    }
+		                }
+		                else {
 					allMatches.push({
 						fileNumber,
 						text: text._.split('\n').map((line: string) => `${fileNumber}: ${line}`).join('\n')
 					});            
-                }
+		                }
 			}
 		}
 	}


### PR DESCRIPTION
I noticed that the preferred language option did not work and only showed the default.
The function expected 'languageNumber' however the setting was labeled as just 'language'.

I figured that while I was messing with the language settings anyway, I could quickly add a toggle to limit the displayed language to show _only_ the preferred language rather than the whole list.

I've not previously worked with vscode extensions, so apologies if it is not up to par.